### PR TITLE
Hash GUID with abi.encode instead of abi.encodePacked

### DIFF
--- a/src/WormholeGUID.sol
+++ b/src/WormholeGUID.sol
@@ -28,7 +28,7 @@ struct WormholeGUID {
 }
 
 function getGUIDHash(WormholeGUID memory wormholeGUID) pure returns (bytes32 guidHash) {
-    guidHash = keccak256(abi.encodePacked(
+    guidHash = keccak256(abi.encode(
         wormholeGUID.sourceDomain,
         wormholeGUID.targetDomain,
         wormholeGUID.receiver,


### PR DESCRIPTION
Following up on the discussion in https://github.com/makerdao/dss-wormhole/pull/3#discussion_r755201358, we need to decide between using abi.encode and abi.encodePacked to hash the wormhole GUID. Both would be safe (no dynamic type is being used) but abi.encode seems to save ~660 gas over abi.encodePacked so I'd suggest to use the former.