### PR TITLE
Change WormholeGUID precision

### DIFF
--- a/src/WormholeGUID.sol
+++ b/src/WormholeGUID.sol
@@ -23,8 +23,8 @@ struct WormholeGUID {
     address receiver;
     address operator;
     uint128 amount;
-    uint64 nonce;
-    uint64 timestamp;
+    uint80 nonce;
+    uint48 timestamp;
 }
 
 function getGUIDHash(WormholeGUID memory wormholeGUID) pure returns (bytes32 guidHash) {


### PR DESCRIPTION
Constrain timestamp down to uint48 - that gives us 9 million years until we run into a problem which I think is fine. I recommend adding another 16 bytes to the nonce. Individual transfers of over ~10^20 DAI (unless the USD implodes) seems less likely than some future where the nonce runs over 10^19. This will boost that the nonce to 10^24 which is more of a ridiculously large number that I think it's better.