### PR TITLE
Add support for linear fees

### DIFF
--- a/src/TeleportLinearFee.sol
+++ b/src/TeleportLinearFee.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.15;
+
+import {TeleportFees} from "./TeleportFees.sol";
+import {TeleportGUID} from "./TeleportGUID.sol";
+
+contract TeleportLinearFee is TeleportFees {
+    uint256 immutable public fee;
+    uint256 immutable public ttl;
+
+    uint256 constant public WAD = 10 ** 18;
+
+    /**
+    * @param _fee Fee percentage in WAD (e.g 1% fee = 0.01 * WAD)
+    * @param _ttl Time in seconds to finalize flush (not teleport)
+    **/
+    constructor(uint256 _fee, uint256 _ttl) {
+        fee = _fee;
+        ttl = _ttl;
+    }
+
+    function getFee(TeleportGUID calldata guid, uint256, int256, uint256, uint256 amtToTake) override external view returns (uint256) {
+        // is slow withdrawal?
+        if (block.timestamp >= uint256(guid.timestamp) + ttl) {
+            return 0;
+        }
+
+        return fee * amtToTake / WAD;
+    }
+}

--- a/src/test/TeleportLinearFee.t.sol
+++ b/src/test/TeleportLinearFee.t.sol
@@ -18,42 +18,28 @@ pragma solidity 0.8.15;
 
 import "ds-test/test.sol";
 
-import "src/TeleportConstantFee.sol";
+import "src/TeleportLinearFee.sol";
 import "src/TeleportGUID.sol";
 
 interface Hevm {
     function warp(uint) external;
 }
 
-contract TeleportConstantFeeTest is DSTest {
-
+contract TeleportLinearFeeTest is DSTest {
+    
     Hevm internal hevm = Hevm(HEVM_ADDRESS);
-    uint256 internal fee = 1 ether / 100;
+    uint256 internal fee = 1 ether / 10000; // 1 BPS fee
     uint256 internal ttl = 8 days;
 
-    TeleportConstantFee internal teleportConstantFee;
+    TeleportLinearFee internal teleportLinearFee;
 
     function setUp() public {
-        teleportConstantFee = new TeleportConstantFee(fee, ttl);
+        teleportLinearFee = new TeleportLinearFee(fee, ttl);
     }
 
     function testConstructor() public {
-        assertEq(teleportConstantFee.fee(), fee);
-        assertEq(teleportConstantFee.ttl(), ttl);
-    }
-
-    function testFeeForZeroAmount() public {
-        TeleportGUID memory guid = TeleportGUID({
-            sourceDomain: "l2network",
-            targetDomain: "ethereum",
-            receiver: addressToBytes32(address(123)),
-            operator: addressToBytes32(address(this)),
-            amount: 0,
-            nonce: 5,
-            timestamp: uint48(block.timestamp)
-        });
-
-        assertEq(teleportConstantFee.getFee(guid, 0, 0, 0, 10 ether), 0);
+        assertEq(teleportLinearFee.fee(), fee);
+        assertEq(teleportLinearFee.ttl(), ttl);
     }
 
     function testFeeForNonZeroAmount() public {
@@ -67,7 +53,7 @@ contract TeleportConstantFeeTest is DSTest {
             timestamp: uint48(block.timestamp)
         });
 
-        assertEq(teleportConstantFee.getFee(guid, 0, 0, 0, 100 ether), fee);
+        assertEq(teleportLinearFee.getFee(guid, 0, 0, 0, 100 ether), 0.01 ether);
     }
 
     function testFeeForSlowMint() public {
@@ -82,6 +68,6 @@ contract TeleportConstantFeeTest is DSTest {
         });
         hevm.warp(block.timestamp + ttl);
 
-        assertEq(teleportConstantFee.getFee(guid, 0, 0, 0, 100 ether), 0);
+        assertEq(teleportLinearFee.getFee(guid, 0, 0, 0, 100 ether), 0);
     }
 }


### PR DESCRIPTION
Add `TeleportLinearFees` to handle fees that are proportional to the withdrawn amount (e.g. "1 bps fee")