### PR TITLE
Add relayer whitelist to BasicRelay

### DIFF
--- a/src/TeleportOracleAuth.sol
+++ b/src/TeleportOracleAuth.sol
@@ -73,14 +73,14 @@ contract TeleportOracleAuth {
     }
 
     function addSigners(address[] calldata signers_) external auth {
-        for(uint i; i < signers_.length; i++) {
+        for(uint256 i; i < signers_.length; i++) {
             signers[signers_[i]] = 1;
         }
         emit SignersAdded(signers_);
     }
 
     function removeSigners(address[] calldata signers_) external auth {
-        for(uint i; i < signers_.length; i++) {
+        for(uint256 i; i < signers_.length; i++) {
             signers[signers_[i]] = 0;
         }
         emit SignersRemoved(signers_);

--- a/src/relays/BasicRelay.sol
+++ b/src/relays/BasicRelay.sol
@@ -136,11 +136,11 @@ contract BasicRelay {
         (uint256 postFeeAmount, uint256 totalFee) = oracleAuth.requestMint(teleportGUID, signatures, maxFeePercentage, gasFee);
         require(postFeeAmount + totalFee == teleportGUID.amount, "BasicRelay/partial-mint-disallowed");
 
-        // Send the gas fee to the relayer
+        // Send the gas fee to the fee collector
         address feeCollector;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            feeCollector := shr(96, calldataload(sub(calldatasize(), 20))) // Gelato uses eip-2771 format to pass feeCollector
+            feeCollector := shr(96, calldataload(sub(calldatasize(), 20))) // Gelato passes the feeCollector in the same way as in EIP-2771
         }
         dai.transfer(feeCollector, gasFee);
     }

--- a/src/relays/BasicRelay.sol
+++ b/src/relays/BasicRelay.sol
@@ -47,7 +47,7 @@ interface TeleportJoinLike {
 // User provides gasFee which is paid to the msg.sender
 contract BasicRelay {
 
-    mapping (address => uint256) public wards;   // Auth
+    mapping (address => uint256) public wards;    // Auth
     mapping (address => uint256) public relayers; // Whitelisted relayers
 
     DaiJoinLike            public immutable daiJoin;
@@ -85,14 +85,14 @@ contract BasicRelay {
     }
 
     function addRelayers(address[] calldata relayers_) external auth {
-        for(uint i; i < relayers_.length; i++) {
+        for(uint256 i; i < relayers_.length; i++) {
             relayers[relayers_[i]] = 1;
         }
         emit RelayersAdded(relayers_);
     }
 
     function removeRelayers(address[] calldata relayers_) external auth {
-        for(uint i; i < relayers_.length; i++) {
+        for(uint256 i; i < relayers_.length; i++) {
             relayers[relayers_[i]] = 0;
         }
         emit RelayersRemoved(relayers_);

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -188,11 +188,11 @@ contract TrustedRelay {
         // Withdraw the L1 DAI to the receiver
         requestMint(teleportGUID, signatures, maxFeePercentage, gasFee, expiry, v, r, s);
 
-        // Send the gas fee to the relayer
+        // Send the gas fee to the fee collector
         address feeCollector;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            feeCollector := shr(96, calldataload(sub(calldatasize(), 20))) // Gelato uses eip-2771 format to pass feeCollector
+            feeCollector := shr(96, calldataload(sub(calldatasize(), 20))) // Gelato passes the feeCollector in the same way as in EIP-2771
         }
         dai.transfer(feeCollector, gasFee);
 

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -158,7 +158,7 @@ contract TrustedRelay {
      * @notice Gasless relay for the Oracle fast path
      * The final signature is ABI-encoded `hashGUID`, `maxFeePercentage`, `gasFee`, `expiry`
      * Must be called by a whitelisted relayer account with the feeCollector address appended
-     * at the end of the calldata, e.g.: `(bool success,) = address(basicRelay).call(abi.encodePacked(relayData, feeCollector));`
+     * at the end of the calldata, e.g.: `(bool success,) = address(trustedRelay).call(abi.encodePacked(relayData, feeCollector));`
      * @param teleportGUID The teleport GUID
      * @param signatures The byte array of concatenated signatures ordered by increasing signer addresses.
      * Each signature is {bytes32 r}{bytes32 s}{uint8 v}

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -126,20 +126,6 @@ contract TrustedRelay {
         emit File(what, data);
     }
 
-    function addSigners(address[] calldata signers_) external toll {
-        for(uint256 i; i < signers_.length; i++) {
-            signers[signers_[i]] = 1;
-        }
-        emit SignersAdded(signers_);
-    }
-
-    function removeSigners(address[] calldata signers_) external toll {
-        for(uint256 i; i < signers_.length; i++) {
-            signers[signers_[i]] = 0;
-        }
-        emit SignersRemoved(signers_);
-    }
-
     function addRelayers(address[] calldata relayers_) external auth {
         for(uint256 i; i < relayers_.length; i++) {
             relayers[relayers_[i]] = 1;
@@ -152,6 +138,20 @@ contract TrustedRelay {
             relayers[relayers_[i]] = 0;
         }
         emit RelayersRemoved(relayers_);
+    }
+
+    function addSigners(address[] calldata signers_) external toll {
+        for(uint256 i; i < signers_.length; i++) {
+            signers[signers_[i]] = 1;
+        }
+        emit SignersAdded(signers_);
+    }
+
+    function removeSigners(address[] calldata signers_) external toll {
+        for(uint256 i; i < signers_.length; i++) {
+            signers[signers_[i]] = 0;
+        }
+        emit SignersRemoved(signers_);
     }
 
     /**

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -168,8 +168,6 @@ contract TrustedRelay {
      * @param v Part of ECDSA signature
      * @param r Part of ECDSA signature
      * @param s Part of ECDSA signature
-     * @param to (optional) The address of an external contract to call after requesting the L1 DAI (address(0) if unused)
-     * @param data (optional) The calldata to use for the call to the aforementionned external contract
      */
     function relay(
         TeleportGUID calldata teleportGUID,
@@ -179,9 +177,7 @@ contract TrustedRelay {
         uint256 expiry,
         uint8 v,
         bytes32 r,
-        bytes32 s,
-        address to,
-        bytes calldata data
+        bytes32 s
     ) external {
         uint256 startGas = gasleft();
 
@@ -195,18 +191,6 @@ contract TrustedRelay {
             feeCollector := shr(96, calldataload(sub(calldatasize(), 20))) // Gelato passes the feeCollector in the same way as in EIP-2771
         }
         dai.transfer(feeCollector, gasFee);
-
-        // Optionally execute an external call
-        if(to != address(0)) {
-            (bool success,) = to.call(data);
-            if (!success) {
-                // solhint-disable-next-line no-inline-assembly
-                assembly {
-                    returndatacopy(0, 0, returndatasize())
-                    revert(0, returndatasize())
-                }
-            }
-        }
 
         // If the eth price oracle is enabled, use its value to check that gasFee is within an allowable margin
         (bytes32 ethPrice, bool ok) = ethPriceOracle.peek();

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -52,9 +52,9 @@ interface DsValueLike {
 // Relay requests are signed by a trusted third-party (typically a backend orchestrating the withdrawal on behalf of the user)
 contract TrustedRelay {
 
-    mapping (address => uint256) public wards;   // Auth (Maker governance)
-    mapping (address => uint256) public buds;    // Admin accounts managing trusted signers
-    mapping (address => uint256) public signers; // Trusted signers
+    mapping (address => uint256) public wards;    // Auth (Maker governance)
+    mapping (address => uint256) public buds;     // Admin accounts managing trusted signers
+    mapping (address => uint256) public signers;  // Trusted signers
     mapping (address => uint256) public relayers; // Whitelisted relayers
     
     uint256                public gasMargin; // in BPS (e.g 150% = 15000)
@@ -141,14 +141,14 @@ contract TrustedRelay {
     }
 
     function addRelayers(address[] calldata relayers_) external auth {
-        for(uint i; i < relayers_.length; i++) {
+        for(uint256 i; i < relayers_.length; i++) {
             relayers[relayers_[i]] = 1;
         }
         emit RelayersAdded(relayers_);
     }
 
     function removeRelayers(address[] calldata relayers_) external auth {
-        for(uint i; i < relayers_.length; i++) {
+        for(uint256 i; i < relayers_.length; i++) {
             relayers[relayers_[i]] = 0;
         }
         emit RelayersRemoved(relayers_);

--- a/src/test/TeleportJoin.t.sol
+++ b/src/test/TeleportJoin.t.sol
@@ -94,6 +94,32 @@ contract TeleportJoinTest is DSTest {
         (ok,) = address(join).call(abi.encodeWithSignature("file(bytes32,bytes32,uint256)", what, domain_, data));
     }
 
+    function _tryRequestMint(
+        TeleportGUID memory teleportGUID,
+        uint256 maxFeePercentage,
+        uint256 operatorFee
+    ) internal returns (bool ok) {
+        (ok,) = address(join).call(abi.encodeWithSignature(
+            "requestMint((bytes32,bytes32,bytes32,bytes32,uint128,uint80,uint48),uint256,uint256)",
+            teleportGUID,
+            maxFeePercentage,
+            operatorFee
+        ));
+    }
+
+    function _tryMintPending(
+        TeleportGUID memory teleportGUID,
+        uint256 maxFeePercentage,
+        uint256 operatorFee
+    ) internal returns (bool ok) {
+        (ok,) = address(join).call(abi.encodeWithSignature(
+            "mintPending((bytes32,bytes32,bytes32,bytes32,uint128,uint80,uint48),uint256,uint256)",
+            teleportGUID,
+            maxFeePercentage,
+            operatorFee
+        ));
+    }
+
     function testConstructor() public {
         assertEq(address(join.vat()), address(vat));
         assertEq(address(join.daiJoin()), address(daiJoin));
@@ -222,7 +248,7 @@ contract TeleportJoinTest is DSTest {
     }
 
 
-    function testFailRegisterAlreadyRegistered() public {
+    function testRegisterAlreadyRegistered() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "ethereum",
@@ -232,11 +258,11 @@ contract TeleportJoinTest is DSTest {
             nonce: 5,
             timestamp: uint48(block.timestamp)
         });
-        join.requestMint(guid, 0, 0);
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
+        assertTrue(!_tryRequestMint(guid, 0, 0));
     }
 
-    function testFailRegisterWrongDomain() public {
+    function testRegisterWrongDomain() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "etherium",
@@ -246,7 +272,7 @@ contract TeleportJoinTest is DSTest {
             nonce: 5,
             timestamp: uint48(block.timestamp)
         });
-        join.requestMint(guid, 0, 0);
+        assertTrue(!_tryRequestMint(guid, 0, 0));
     }
 
     function testRegisterAndWithdrawPayingFee() public {
@@ -276,7 +302,7 @@ contract TeleportJoinTest is DSTest {
         assertEq(totalFee, 100 ether);
     }
 
-    function testFailRegisterAndWithdrawPayingFee() public {
+    function testRegisterAndWithdrawPayingInsufficientFee() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "ethereum",
@@ -288,7 +314,7 @@ contract TeleportJoinTest is DSTest {
         });
 
         join.file("fees", "l2network", address(new TeleportConstantFee(100 ether, TTL)));
-        join.requestMint(guid, 3 * WAD / 10000, 0); // 0.03% * 250K < 100 (not enough)
+        assertTrue(!_tryRequestMint(guid, 3 * WAD / 10000, 0)); // 0.03% * 250K < 100 (not enough)
     }
 
     function testRegisterAndWithdrawFeeTTLExpires() public {
@@ -307,7 +333,7 @@ contract TeleportJoinTest is DSTest {
 
         join.file("fees", "l2network", address(fees));
         hevm.warp(block.timestamp + TTL + 1 days);    // Over ttl - you don't pay fees
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(vat.dai(vow), 0);
         assertEq(dai.balanceOf(address(123)), 250_000 ether);
@@ -332,7 +358,7 @@ contract TeleportJoinTest is DSTest {
 
         join.file("line", "l2network", 200_000 ether);
         join.file("fees", "l2network", address(new TeleportConstantFee(100 ether, TTL)));
-        join.requestMint(guid, 4 * WAD / 10000, 0); // 0.04% * 200K = 80 (just enough as fee is also proportional)
+        assertTrue(_tryRequestMint(guid, 4 * WAD / 10000, 0)); // 0.04% * 200K = 80 (just enough as fee is also proportional)
 
         assertEq(vat.dai(vow), 80 * RAD);
         assertEq(dai.balanceOf(address(123)), 199_920 ether);
@@ -344,7 +370,7 @@ contract TeleportJoinTest is DSTest {
 
         join.file("line", "l2network", 250_000 ether);
 
-        join.mintPending(guid, 4 * WAD / 10000, 0); // 0.04% * 50 = 20 (just enough as fee is also proportional)
+        assertTrue(_tryMintPending(guid, 4 * WAD / 10000, 0)); // 0.04% * 50 = 20 (just enough as fee is also proportional)
 
         assertEq(vat.dai(vow), 100 * RAD);
         assertEq(dai.balanceOf(address(123)), 249_900 ether);
@@ -354,7 +380,7 @@ contract TeleportJoinTest is DSTest {
         assertEq(join.cure(), 250_000 * RAD);
     }
 
-    function testFailRegisterAndWithdrawPartialPayingFee() public {
+    function testRegisterAndWithdrawPartialPayingInsufficientFee() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "ethereum",
@@ -369,10 +395,10 @@ contract TeleportJoinTest is DSTest {
 
         join.file("line", "l2network", 200_000 ether);
         join.file("fees", "l2network", address(new TeleportConstantFee(100 ether, TTL)));
-        join.requestMint(guid, 3 * WAD / 10000, 0); // 0.03% * 200K < 80 (not enough)
+        assertTrue(!_tryRequestMint(guid, 3 * WAD / 10000, 0)); // 0.03% * 200K < 80 (not enough)
     }
 
-    function testFailRegisterAndWithdrawPartialPayingFee2() public {
+    function testRegisterAndWithdrawPartialPayingFee2() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "ethereum",
@@ -387,11 +413,11 @@ contract TeleportJoinTest is DSTest {
 
         join.file("line", "l2network", 200_000 ether);
         join.file("fees", "l2network", address(new TeleportConstantFee(100 ether, TTL)));
-        join.requestMint(guid, 4 * WAD / 10000, 0);
+        assertTrue(_tryRequestMint(guid, 4 * WAD / 10000, 0));
 
         join.file("line", "l2network", 250_000 ether);
 
-        join.mintPending(guid, 3 * WAD / 10000, 0); // 0.03% * 50 < 20 (not enough)
+        assertTrue(!_tryMintPending(guid, 3 * WAD / 10000, 0)); // 0.03% * 50 < 20 (not enough)
     }
 
     function testMintPendingByOperator() public {
@@ -406,14 +432,14 @@ contract TeleportJoinTest is DSTest {
         });
 
         join.file("line", "l2network", 200_000 ether);
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(this)), 200_000 ether);
         assertTrue(_blessed(guid));
         assertEq(_pending(guid), 50_000 ether);
 
         join.file("line", "l2network", 225_000 ether);
-        join.mintPending(guid, 0, 0);
+        assertTrue(_tryMintPending(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(this)), 225_000 ether);
         assertEq(_pending(guid), 25_000 ether);
@@ -431,14 +457,14 @@ contract TeleportJoinTest is DSTest {
         });
 
         join.file("line", "l2network", 200_000 ether);
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(123)), 200_000 ether);
         assertTrue(_blessed(guid));
         assertEq(_pending(guid), 50_000 ether);
 
         join.file("line", "l2network", 225_000 ether);
-        join.mintPending(guid, 0, 0);
+        assertTrue(_tryMintPending(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(123)), 225_000 ether);
         assertEq(_pending(guid), 25_000 ether);
@@ -456,20 +482,20 @@ contract TeleportJoinTest is DSTest {
         });
 
         join.file("line", "l2network", 200_000 ether);
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(this)), 200_000 ether);
         assertTrue(_blessed(guid));
         assertEq(_pending(guid), 50_000 ether);
 
         join.file("line", "l2network", 225_000 ether);
-        join.mintPending(guid, 0, 0);
+        assertTrue(_tryMintPending(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(this)), 225_000 ether);
         assertEq(_pending(guid), 25_000 ether);
     }
 
-    function testFailMintPendingWrongOperator() public {
+    function testMintPendingWrongOperator() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "ethereum",
@@ -481,10 +507,10 @@ contract TeleportJoinTest is DSTest {
         });
 
         join.file("line", "l2network", 200_000 ether);
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         join.file("line", "l2network", 225_000 ether);
-        join.mintPending(guid, 0, 0);
+        assertTrue(!_tryMintPending(guid, 0, 0));
     }
 
     function testSettle() public {
@@ -518,7 +544,7 @@ contract TeleportJoinTest is DSTest {
             timestamp: uint48(block.timestamp)
         });
 
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(123)), 250_000 ether);
         assertEq(_ink(), 150_000 ether);
@@ -546,7 +572,7 @@ contract TeleportJoinTest is DSTest {
         });
 
         join.file("line", "l2network", 100_000 ether);
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(123)), 200_000 ether);
         assertEq(_pending(guid), 50_000 ether);
@@ -578,7 +604,7 @@ contract TeleportJoinTest is DSTest {
         assertEq(vat.live(), 0);
 
         join.file("fees", "l2network", address(new TeleportConstantFee(100 ether, TTL)));
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(dai.balanceOf(address(123)), 100_000 ether); // Can't pay more than DAI is already in the join
         assertEq(_pending(guid), 150_000 ether);
@@ -599,7 +625,7 @@ contract TeleportJoinTest is DSTest {
             timestamp: uint48(block.timestamp)
         });
 
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(join.debt("l2network"), 250_000 ether);
         assertEq(_ink(), 250_000 ether);
@@ -641,7 +667,7 @@ contract TeleportJoinTest is DSTest {
         assertEq(totalFee, 250 ether);
     }
 
-    function testFailOperatorFeeTooHigh() public {
+    function testOperatorFeeTooHigh() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "ethereum",
@@ -651,7 +677,7 @@ contract TeleportJoinTest is DSTest {
             nonce: 5,
             timestamp: uint48(block.timestamp)
         });
-        join.requestMint(guid, 0, 250_001 ether);   // Slightly over the amount
+        assertTrue(!_tryRequestMint(guid, 0, 250_001 ether));   // Slightly over the amount
     }
 
     function testRegisterAndWithdrawPartialPayingOperatorFee() public {
@@ -666,7 +692,7 @@ contract TeleportJoinTest is DSTest {
         });
 
         join.file("line", "l2network", 200_000 ether);
-        join.requestMint(guid, 0, 200 ether);
+        assertTrue(_tryRequestMint(guid, 0, 200 ether));
 
         assertEq(dai.balanceOf(address(this)), 200 ether);
         assertEq(dai.balanceOf(address(123)), 199_800 ether);
@@ -676,7 +702,7 @@ contract TeleportJoinTest is DSTest {
         assertEq(_art(), 200_000 ether);
 
         join.file("line", "l2network", 250_000 ether);
-        join.mintPending(guid, 0, 5 ether);
+        assertTrue(_tryMintPending(guid, 0, 5 ether));
 
         assertEq(dai.balanceOf(address(this)), 205 ether);
         assertEq(dai.balanceOf(address(123)), 249_795 ether);
@@ -697,7 +723,7 @@ contract TeleportJoinTest is DSTest {
         });
         assertEq(dai.balanceOf(address(this)), 0);
         join.file("fees", "l2network", address(new TeleportConstantFee(1000 ether, TTL)));
-        join.requestMint(guid, 40 ether / 10000, 249 ether);
+        assertTrue(_tryRequestMint(guid, 40 ether / 10000, 249 ether));
         assertEq(dai.balanceOf(address(this)), 249 ether);
         assertEq(vat.dai(vow), 1000 * RAD);
         assertEq(dai.balanceOf(address(123)), 248_751 ether);
@@ -706,7 +732,7 @@ contract TeleportJoinTest is DSTest {
         assertEq(_art(), 250_000 ether);
     }
 
-    function testFailRegisterAndWithdrawOperatorFeeTooHigh() public {
+    function testRegisterAndWithdrawOperatorFeeTooHigh() public {
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
             targetDomain: "ethereum",
@@ -717,7 +743,7 @@ contract TeleportJoinTest is DSTest {
             timestamp: uint48(block.timestamp)
         });
         join.file("fees", "l2network", address(new TeleportConstantFee(1000 ether, TTL)));
-        join.requestMint(guid, 40 ether / 10000, 249_001 ether);    // Too many fees
+        assertTrue(!_tryRequestMint(guid, 40 ether / 10000, 249_001 ether));    // Too many fees
     }
 
     function testTotalDebtSeveralDomains() public {
@@ -739,7 +765,7 @@ contract TeleportJoinTest is DSTest {
             nonce: 5,
             timestamp: uint48(block.timestamp)
         });
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         guid = TeleportGUID({
             sourceDomain: "l2network_3",
@@ -750,7 +776,7 @@ contract TeleportJoinTest is DSTest {
             nonce: 5,
             timestamp: uint48(block.timestamp)
         });
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(join.debt("l2network"), -100_000 ether);
         assertEq(join.debt("l2network_2"), 150_000 ether);
@@ -766,7 +792,7 @@ contract TeleportJoinTest is DSTest {
             nonce: 5,
             timestamp: uint48(block.timestamp)
         });
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(join.debt("l2network"), -50_000 ether);
         assertEq(join.debt("l2network_2"), 150_000 ether);
@@ -794,7 +820,7 @@ contract TeleportJoinTest is DSTest {
             timestamp: uint48(block.timestamp)
         });
 
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(_ink(), 250_000 ether);
         assertEq(_art(), 250_000 ether);
@@ -820,7 +846,7 @@ contract TeleportJoinTest is DSTest {
             timestamp: uint48(block.timestamp)
         });
 
-        join.requestMint(guid, 0, 0);
+        assertTrue(_tryRequestMint(guid, 0, 0));
 
         assertEq(_ink(), 350_000 ether);
         assertEq(_art(), 100_000 ether);

--- a/src/test/relays/BasicRelay.t.sol
+++ b/src/test/relays/BasicRelay.t.sol
@@ -228,7 +228,7 @@ contract BasicRelayTest is DSTest {
 
     function test_relay() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address receiver = hevm.addr(sk);
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
@@ -270,9 +270,9 @@ contract BasicRelayTest is DSTest {
         assertEq(dai.balanceOf(feeCollector), 1 ether);
     }
 
-    function testFail_relay_expired() public {
+    function test_relay_expired() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address receiver = hevm.addr(sk);
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
@@ -297,7 +297,7 @@ contract BasicRelayTest is DSTest {
 
         hevm.warp(block.timestamp + 1);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -309,9 +309,9 @@ contract BasicRelayTest is DSTest {
         ));
     }
 
-    function testFail_relay_bad_signature() public {
+    function test_relay_bad_signature() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address receiver = hevm.addr(sk);
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
@@ -334,7 +334,7 @@ contract BasicRelayTest is DSTest {
 
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -346,7 +346,7 @@ contract BasicRelayTest is DSTest {
         ));
     }
 
-    function testFail_relay_partial_mint() public {
+    function test_relay_partial_mint() public {
         join.setMaxMint(50 ether);
 
         _whitelistThis();
@@ -373,7 +373,7 @@ contract BasicRelayTest is DSTest {
 
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -385,8 +385,8 @@ contract BasicRelayTest is DSTest {
         ));
     }
 
-    function testFail_relayer_not_whitelisted() public {
-        uint256 sk = uint(keccak256(abi.encode(8)));
+    function test_relayer_not_whitelisted() public {
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address receiver = hevm.addr(sk);
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
@@ -409,7 +409,7 @@ contract BasicRelayTest is DSTest {
 
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,

--- a/src/test/relays/BasicRelay.t.sol
+++ b/src/test/relays/BasicRelay.t.sol
@@ -214,7 +214,8 @@ contract BasicRelayTest is DSTest {
 
         assertEq(dai.balanceOf(receiver), 0);
         assertEq(dai.balanceOf(address(this)), 0);
-        relay.relay(
+
+        bytes memory relayData = abi.encodeWithSelector(relay.relay.selector, 
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -224,9 +225,13 @@ contract BasicRelayTest is DSTest {
             r,
             s
         );
+        address feeCollector = address(0xf33C0113c702);
+        (bool success,) = address(relay).call(abi.encodePacked(relayData, feeCollector));
+        assertTrue(success);
+
         // Should get 100 DAI - 1% teleport fee - 1 DAI gas fee
         assertEq(dai.balanceOf(receiver), 98 ether);
-        assertEq(dai.balanceOf(address(this)), 1 ether);
+        assertEq(dai.balanceOf(feeCollector), 1 ether);
     }
 
     function testFail_relay_expired() public {

--- a/src/test/relays/BasicRelay.t.sol
+++ b/src/test/relays/BasicRelay.t.sol
@@ -314,7 +314,7 @@ contract BasicRelayTest is DSTest {
         join.setMaxMint(50 ether);
 
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address receiver = hevm.addr(sk);
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",

--- a/src/test/relays/BasicRelay.t.sol
+++ b/src/test/relays/BasicRelay.t.sol
@@ -270,6 +270,50 @@ contract BasicRelayTest is DSTest {
         assertEq(dai.balanceOf(feeCollector), 1 ether);
     }
 
+    function test_relay_no_fee_collector() public {
+        _whitelistThis();
+        uint256 sk = uint256(keccak256(abi.encode(8)));
+        address receiver = hevm.addr(sk);
+        TeleportGUID memory guid = TeleportGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = WAD;                       // 1 DAI of gas
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage,
+            gasFee,
+            expiry
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        assertEq(dai.balanceOf(receiver), 0);
+
+        // relay() should succeed even without the appended feeCollector
+        // but the fee will be sent to an incorrect address
+        relay.relay(
+            guid,
+            "",
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+
+        // Should get 100 DAI - 1% teleport fee - 1 DAI gas fee
+        assertEq(dai.balanceOf(receiver), 98 ether);
+    }
+
     function test_relay_expired() public {
         _whitelistThis();
         uint256 sk = uint256(keccak256(abi.encode(8)));

--- a/src/test/relays/BasicRelay.t.sol
+++ b/src/test/relays/BasicRelay.t.sol
@@ -141,6 +141,14 @@ contract BasicRelayTest is DSTest {
         (ok,) = address(relay).call(abi.encodeWithSignature("deny(address)", usr));
     }
 
+    function _tryAddRelayers(address[] memory relayers) internal returns (bool ok) {
+        (ok,) = address(relay).call(abi.encodeWithSignature("addRelayers(address[])", relayers));
+    }
+
+    function _tryRemoveRelayers(address[] memory relayers) internal returns (bool ok) {
+        (ok,) = address(relay).call(abi.encodeWithSignature("removeRelayers(address[])", relayers));
+    }
+
     function _tryRelay(
         TeleportGUID memory teleportGUID,
         bytes memory signatures,
@@ -167,7 +175,7 @@ contract BasicRelayTest is DSTest {
     function _whitelistThis() internal {
         address[] memory relayers = new address[](1);
         relayers[0] = address(this);
-        relay.addRelayers(relayers);
+        assertTrue(_tryAddRelayers(relayers));
     }
 
     function test_constructor_args() public {
@@ -198,17 +206,24 @@ contract BasicRelayTest is DSTest {
             assertEq(relay.relayers(address(uint160(i))), 0);
         }
 
-        relay.addRelayers(relayers);
+        assertTrue(_tryAddRelayers(relayers));
 
         for(uint i; i < relayers.length; i++) {
             assertEq(relay.relayers(address(uint160(i))), 1);
         }
 
-        relay.removeRelayers(relayers);
+        assertTrue(_tryRemoveRelayers(relayers));
 
         for(uint i; i < relayers.length; i++) {
             assertEq(relay.relayers(address(uint160(i))), 0);
         }
+
+        assertTrue(_tryDeny(address(this)));
+
+        assertEq(relay.wards(address(this)), 0);
+
+        assertTrue(!_tryAddRelayers(relayers));
+        assertTrue(!_tryRemoveRelayers(relayers));
     }
 
     function test_relay() public {

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -213,7 +213,7 @@ contract TrustedRelayTest is DSTest {
         address to,
         bytes memory data
     ) internal returns (bool ok) {
-        bytes memory relayData = abi.encodeWithSelector(relay.relay.selector, 
+        bytes memory relayData = abi.encodeWithSelector(relay.relay.selector,
             teleportGUID,
             signatures,
             maxFeePercentage,
@@ -695,7 +695,7 @@ contract TrustedRelayTest is DSTest {
 
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        relay.relay(
+        assertTrue(_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -706,7 +706,7 @@ contract TrustedRelayTest is DSTest {
             s,
             address(0),
             ""
-        );
+        ));
     }
 
     function testFail_relay_excessive_fee() public {

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -387,6 +387,51 @@ contract TrustedRelayTest is DSTest {
         assertEq(dai.balanceOf(feeCollector), 1 ether);
     }
 
+    function test_relay_no_fee_collector() public {
+        _whitelistThis();
+        uint256 sk = uint256(keccak256(abi.encode(8)));
+        address receiver = hevm.addr(sk);
+        TeleportGUID memory guid = TeleportGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = WAD;                       // 1 DAI of gas
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage,
+            gasFee,
+            expiry
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        assertEq(dai.balanceOf(receiver), 0);
+
+        // relay() should succeed even without the appended feeCollector
+        // but the fee will be sent to an incorrect address
+        relay.relay(
+            guid,
+            "",
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+
+        // Should get 100 DAI - 1% teleport fee - 1 DAI gas fee
+        assertEq(dai.balanceOf(receiver), 98 ether);
+    }
+
+
     function test_relay_when_receiver_is_signer() public {
         _whitelistThis();
         uint256 sk = uint256(keccak256(abi.encode(8)));

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -383,7 +383,7 @@ contract TrustedRelayTest is DSTest {
 
         // Should get 100 DAI - 1% teleport fee - 1 DAI gas fee
         assertEq(dai.balanceOf(receiver), 98 ether);
-        assertEq(dai.balanceOf(feeCollector), 1 ether);        
+        assertEq(dai.balanceOf(feeCollector), 1 ether);
     }
 
     function test_relay_when_receiver_is_signer() public {

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -201,6 +201,14 @@ contract TrustedRelayTest is DSTest {
         (ok,) = address(relay).call(abi.encodeWithSignature("removeSigners(address[])", signers));
     }
 
+    function _tryAddRelayers(address[] memory relayers) internal returns (bool ok) {
+        (ok,) = address(relay).call(abi.encodeWithSignature("addRelayers(address[])", relayers));
+    }
+
+    function _tryRemoveRelayers(address[] memory relayers) internal returns (bool ok) {
+        (ok,) = address(relay).call(abi.encodeWithSignature("removeRelayers(address[])", relayers));
+    }
+
     function _tryRelay(
         TeleportGUID memory teleportGUID,
         bytes memory signatures,
@@ -325,18 +333,26 @@ contract TrustedRelayTest is DSTest {
             assertEq(relay.relayers(address(uint160(i))), 0);
         }
 
-        relay.addRelayers(relayers);
+        assertTrue(_tryAddRelayers(relayers));
 
         for(uint i; i < relayers.length; i++) {
             assertEq(relay.relayers(address(uint160(i))), 1);
         }
 
-        relay.removeRelayers(relayers);
+        assertTrue(_tryRemoveRelayers(relayers));
 
         for(uint i; i < relayers.length; i++) {
             assertEq(relay.relayers(address(uint160(i))), 0);
         }
+
+        assertTrue(_tryDeny(address(this)));
+
+        assertEq(relay.wards(address(this)), 0);
+
+        assertTrue(!_tryAddRelayers(relayers));
+        assertTrue(!_tryRemoveRelayers(relayers));
     }
+
 
     function test_relay_with_trusted_signer() public {
         _whitelistThis();

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -277,8 +277,8 @@ contract TrustedRelayTest is DSTest {
         assertEq(relay.gasMargin(), 3);
     }
 
-    function testFailFileInvalidWhat() public {
-        relay.file("meh", 888);
+    function testFileInvalidWhat() public {
+        assertTrue(!_tryFile("meh", 888));
     }
 
     function testKissDiss() public {
@@ -404,7 +404,7 @@ contract TrustedRelayTest is DSTest {
 
     function test_relay_when_receiver_is_signer() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address receiver = hevm.addr(sk);
         TeleportGUID memory guid = TeleportGUID({
             sourceDomain: "l2network",
@@ -449,7 +449,7 @@ contract TrustedRelayTest is DSTest {
 
     function test_relay_with_ext_call() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -505,7 +505,7 @@ contract TrustedRelayTest is DSTest {
         (bytes32 prevPrice,) = ethPriceOracle.peek();
         ethPriceOracle.void();
 
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -555,9 +555,9 @@ contract TrustedRelayTest is DSTest {
         ethPriceOracle.poke(prevPrice);
     }
 
-    function testFail_relay_expired() public {
+    function test_relay_expired() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -585,7 +585,7 @@ contract TrustedRelayTest is DSTest {
 
         hevm.warp(block.timestamp + 1);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -599,9 +599,9 @@ contract TrustedRelayTest is DSTest {
         ));
     }
 
-    function testFail_relay_bad_signature() public {
+    function test_relay_bad_signature() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -628,7 +628,7 @@ contract TrustedRelayTest is DSTest {
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -642,7 +642,7 @@ contract TrustedRelayTest is DSTest {
         ));
     }
 
-    function testFail_relay_bad_signer() public {
+    function test_relay_bad_signer() public {
         _whitelistThis();
         address receiver = address(123);
         TeleportGUID memory guid = TeleportGUID({
@@ -664,10 +664,10 @@ contract TrustedRelayTest is DSTest {
             expiry
         );
 
-        uint256 sk = uint(keccak256(abi.encode(888)));
+        uint256 sk = uint256(keccak256(abi.encode(888)));
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -681,11 +681,11 @@ contract TrustedRelayTest is DSTest {
         ));
     }
 
-    function testFail_relay_partial_mint() public {
+    function test_relay_partial_mint() public {
         _whitelistThis();
         join.setMaxMint(50 ether);
 
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -711,7 +711,7 @@ contract TrustedRelayTest is DSTest {
 
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -725,9 +725,9 @@ contract TrustedRelayTest is DSTest {
         ));
     }
 
-    function testFail_relay_excessive_fee() public {
+    function test_relay_excessive_fee() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -753,7 +753,7 @@ contract TrustedRelayTest is DSTest {
 
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,
@@ -769,7 +769,7 @@ contract TrustedRelayTest is DSTest {
 
     function test_relay_with_reverting_ext_call() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -809,8 +809,8 @@ contract TrustedRelayTest is DSTest {
         ));
     }
 
-    function testFail_relayer_not_whitelisted() public {
-        uint256 sk = uint(keccak256(abi.encode(8)));
+    function test_relayer_not_whitelisted() public {
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);
@@ -836,7 +836,7 @@ contract TrustedRelayTest is DSTest {
 
         (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
 
-        assertTrue(_tryRelay(
+        assertTrue(!_tryRelay(
             guid,
             "",     // Not testing OracleAuth signatures here
             maxFeePercentage,

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -340,7 +340,7 @@ contract TrustedRelayTest is DSTest {
 
     function test_relay_with_trusted_signer() public {
         _whitelistThis();
-        uint256 sk = uint(keccak256(abi.encode(8)));
+        uint256 sk = uint256(keccak256(abi.encode(8)));
         address[] memory signers = new address[](1);
         signers[0] = hevm.addr(sk);
         relay.addSigners(signers);


### PR DESCRIPTION
1. Adds a relayer whitelist to mitigate MEV concerns.
2. Extract feeCollector address from calldata appendix.
3. Replace `testFailXXX` with explicit revert tests.
4. Remove option to bundle external call to `relay()` in TrustedRelay.