### PR TITLE
Allow permissionless relays when gasFee=0

### DIFF
--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -387,6 +387,51 @@ contract TrustedRelayTest is DSTest {
         assertEq(dai.balanceOf(feeCollector), 1 ether);
     }
 
+    function test_relay_not_whitelisted_no_refund() public {
+        uint256 sk = uint256(keccak256(abi.encode(8)));
+        address[] memory signers = new address[](1);
+        signers[0] = hevm.addr(sk);
+        relay.addSigners(signers);
+        address receiver = address(123);
+        TeleportGUID memory guid = TeleportGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = 0;                         // no refund requested
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage,
+            gasFee,
+            expiry
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        assertEq(dai.balanceOf(receiver), 0);
+
+        // relay() should succeed even without the sender being whitelisted given that gasFee == 0
+        relay.relay(
+            guid,
+            "",     // Not testing OracleAuth signatures here
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+
+        // Should get 100 DAI - 1% teleport fee
+        assertEq(dai.balanceOf(receiver), 99 ether);
+    }
+
     function test_relay_no_fee_collector() public {
         _whitelistThis();
         uint256 sk = uint256(keccak256(abi.encode(8)));


### PR DESCRIPTION
Motivated by https://github.com/makerdao/dss-teleport/issues/104#issuecomment-1442760685.

~~Pending discussions with Gelato as this implementation may still open the door to frontrunners chasing more complex MEV arbitrage than the collection of the refund fee and it may therefore be preferable to deploy a separate relay contract to enable permissionless relays.~~

Edit: this PR was discussed with (and approved by) the Gelato team. This implementation is not expected to open new MEV exploitation pathways that wouldn't also be achievable by other means.
